### PR TITLE
Rename core/posts to core/blog

### DIFF
--- a/internal/adapters/postrepo/filesystem/parser.go
+++ b/internal/adapters/postrepo/filesystem/parser.go
@@ -5,19 +5,19 @@ import (
 	"strings"
 	"time"
 
-	"github.com/geisonbiazus/blog/internal/core/posts"
+	"github.com/geisonbiazus/blog/internal/core/blog"
 )
 
 var ErrInvalidTime = errors.New("invalid time format, please use YYYY-MM-DD HH:MM")
 var ErrInvalidFormat = errors.New("invalid file format, please include a header / body separator \"--\"")
 
-func ParseFileContent(content string) (posts.Post, error) {
+func ParseFileContent(content string) (blog.Post, error) {
 	return newParser(content).parse()
 }
 
 type parser struct {
 	content string
-	post    posts.Post
+	post    blog.Post
 	err     error
 }
 
@@ -25,7 +25,7 @@ func newParser(content string) *parser {
 	return &parser{content: content}
 }
 
-func (p *parser) parse() (posts.Post, error) {
+func (p *parser) parse() (blog.Post, error) {
 	header, body := p.splitHeaderAndBody()
 
 	p.parseHeader(header)

--- a/internal/adapters/postrepo/filesystem/parser_test.go
+++ b/internal/adapters/postrepo/filesystem/parser_test.go
@@ -5,21 +5,21 @@ import (
 	"time"
 
 	"github.com/geisonbiazus/blog/internal/adapters/postrepo/filesystem"
-	"github.com/geisonbiazus/blog/internal/core/posts"
+	"github.com/geisonbiazus/blog/internal/core/blog"
 	"github.com/geisonbiazus/blog/pkg/assert"
 )
 
 func TestParseFileContent(t *testing.T) {
 	t.Run("It parses content header into a Post", func(t *testing.T) {
-		assertParsedContent(t, "title: Post Title\n--\n", posts.Post{Title: "Post Title"})
-		assertParsedContent(t, "author: Author Name\n--\n", posts.Post{Author: "Author Name"})
-		assertParsedContent(t, "time: 2021-04-04 22:00\n--\n", posts.Post{Time: toTime("2021-04-04T22:00:00Z")})
+		assertParsedContent(t, "title: Post Title\n--\n", blog.Post{Title: "Post Title"})
+		assertParsedContent(t, "author: Author Name\n--\n", blog.Post{Author: "Author Name"})
+		assertParsedContent(t, "time: 2021-04-04 22:00\n--\n", blog.Post{Time: toTime("2021-04-04T22:00:00Z")})
 		assertParsedContent(t, ""+
 			"title: Post Title\n"+
 			"author: Author Name\n"+
 			"time: 2021-04-04 22:00\n"+
 			"--\n",
-			posts.Post{
+			blog.Post{
 				Title:  "Post Title",
 				Author: "Author Name",
 				Time:   toTime("2021-04-04T22:00:00Z"),
@@ -30,7 +30,7 @@ func TestParseFileContent(t *testing.T) {
 		assertParsedContent(t, ""+
 			"--\n"+
 			"Content\n",
-			posts.Post{
+			blog.Post{
 				Content: "" +
 					"Content\n",
 			})
@@ -40,7 +40,7 @@ func TestParseFileContent(t *testing.T) {
 			"Only first separator is considered\n"+
 			"--\n"+
 			"After second separator\n",
-			posts.Post{
+			blog.Post{
 				Content: "" +
 					"Only first separator is considered\n" +
 					"--\n" +
@@ -60,7 +60,7 @@ func TestParseFileContent(t *testing.T) {
 			"Content\n"+
 			"--\n"+
 			"- list\n",
-			posts.Post{
+			blog.Post{
 				Title:  "Post Title",
 				Author: "Author Name",
 				Time:   toTime("2021-04-04T22:00:00Z"),
@@ -84,7 +84,7 @@ func TestParseFileContent(t *testing.T) {
 	})
 }
 
-func assertParsedContent(t *testing.T, content string, expectedPost posts.Post) {
+func assertParsedContent(t *testing.T, content string, expectedPost blog.Post) {
 	t.Helper()
 	post, err := filesystem.ParseFileContent(content)
 	assert.DeepEqual(t, expectedPost, post)
@@ -94,7 +94,7 @@ func assertParsedContent(t *testing.T, content string, expectedPost posts.Post) 
 func assertParseError(t *testing.T, content string, expectedError error) {
 	t.Helper()
 	post, err := filesystem.ParseFileContent(content)
-	assert.DeepEqual(t, posts.Post{}, post)
+	assert.DeepEqual(t, blog.Post{}, post)
 	assert.Equal(t, expectedError, err)
 }
 

--- a/internal/adapters/postrepo/filesystem/post_repo.go
+++ b/internal/adapters/postrepo/filesystem/post_repo.go
@@ -9,7 +9,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/geisonbiazus/blog/internal/core/posts"
+	"github.com/geisonbiazus/blog/internal/core/blog"
 )
 
 type PostRepo struct {
@@ -20,11 +20,11 @@ func NewPostRepo(basePath string) *PostRepo {
 	return &PostRepo{BasePath: basePath}
 }
 
-func (r *PostRepo) GetPostByPath(path string) (posts.Post, error) {
+func (r *PostRepo) GetPostByPath(path string) (blog.Post, error) {
 	content, err := ioutil.ReadFile(filepath.Join(r.BasePath, path+".md"))
 
 	if err != nil {
-		return posts.Post{}, posts.ErrPostNotFound
+		return blog.Post{}, blog.ErrPostNotFound
 	}
 
 	post, err := ParseFileContent(string(content))
@@ -33,24 +33,24 @@ func (r *PostRepo) GetPostByPath(path string) (posts.Post, error) {
 	return post, err
 }
 
-func (r *PostRepo) GetAllPosts() ([]posts.Post, error) {
-	postList := []posts.Post{}
+func (r *PostRepo) GetAllPosts() ([]blog.Post, error) {
+	posts := []blog.Post{}
 	entries, err := os.ReadDir(r.BasePath)
 
 	if err != nil {
-		return postList, err
+		return posts, err
 	}
 
 	for _, entry := range entries {
-		postList = r.maybeLoadPostFromFile(postList, entry)
+		posts = r.maybeLoadPostFromFile(posts, entry)
 	}
 
-	return r.sortPostsByTimeDesc(postList), err
+	return r.sortPostsByTimeDesc(posts), err
 }
 
-func (r *PostRepo) maybeLoadPostFromFile(postList []posts.Post, entry fs.DirEntry) []posts.Post {
+func (r *PostRepo) maybeLoadPostFromFile(posts []blog.Post, entry fs.DirEntry) []blog.Post {
 	if !strings.HasSuffix(entry.Name(), ".md") {
-		return postList
+		return posts
 	}
 
 	fileName := strings.TrimSuffix(entry.Name(), ".md")
@@ -59,16 +59,16 @@ func (r *PostRepo) maybeLoadPostFromFile(postList []posts.Post, entry fs.DirEntr
 	if err != nil {
 		log.Printf("WARNING: error loading post \"%s\": %v", fileName, err)
 
-		return postList
+		return posts
 	}
 
-	return append(postList, post)
+	return append(posts, post)
 }
 
-func (r *PostRepo) sortPostsByTimeDesc(postList []posts.Post) []posts.Post {
-	sort.Slice(postList, func(i, j int) bool {
-		return postList[i].Time.After(postList[j].Time)
+func (r *PostRepo) sortPostsByTimeDesc(posts []blog.Post) []blog.Post {
+	sort.Slice(posts, func(i, j int) bool {
+		return posts[i].Time.After(posts[j].Time)
 	})
 
-	return postList
+	return posts
 }

--- a/internal/adapters/postrepo/filesystem/post_repo_test.go
+++ b/internal/adapters/postrepo/filesystem/post_repo_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/geisonbiazus/blog/internal/adapters/postrepo/filesystem"
-	"github.com/geisonbiazus/blog/internal/core/posts"
+	"github.com/geisonbiazus/blog/internal/core/blog"
 	"github.com/geisonbiazus/blog/pkg/assert"
 )
 
@@ -21,8 +21,8 @@ func TestPostRepo(t *testing.T) {
 
 			post, err := repo.GetPostByPath("wrong_path")
 
-			assert.DeepEqual(t, posts.Post{}, post)
-			assert.Equal(t, posts.ErrPostNotFound, err)
+			assert.DeepEqual(t, blog.Post{}, post)
+			assert.Equal(t, blog.ErrPostNotFound, err)
 		})
 
 		t.Run("It returns parsed post when the file exists", func(t *testing.T) {
@@ -38,23 +38,23 @@ func TestPostRepo(t *testing.T) {
 	t.Run("GetAllPosts()", func(t *testing.T) {
 		t.Run("Given a path with no post files, it returns empty", func(t *testing.T) {
 			repo := filesystem.NewPostRepo(emptyFolder)
-			postList, err := repo.GetAllPosts()
+			posts, err := repo.GetAllPosts()
 
-			assert.DeepEqual(t, []posts.Post{}, postList)
+			assert.DeepEqual(t, []blog.Post{}, posts)
 			assert.Nil(t, err)
 		})
 
 		t.Run("Given a non-existent path, it returns error", func(t *testing.T) {
 			repo := filesystem.NewPostRepo(invalidPath)
-			postList, err := repo.GetAllPosts()
+			posts, err := repo.GetAllPosts()
 
-			assert.DeepEqual(t, []posts.Post{}, postList)
+			assert.DeepEqual(t, []blog.Post{}, posts)
 			assert.NotNil(t, err)
 		})
 
 		t.Run("Given a path with post files, it returns all posts sorted by descending date", func(t *testing.T) {
 			repo := filesystem.NewPostRepo(postPath)
-			expectedPosts := []posts.Post{testPost1, testPost3, testPost2}
+			expectedPosts := []blog.Post{testPost1, testPost3, testPost2}
 
 			actualPosts, err := repo.GetAllPosts()
 
@@ -64,7 +64,7 @@ func TestPostRepo(t *testing.T) {
 
 		t.Run("Given an invalid post in the folder, it ignores the invalid and returns the rest", func(t *testing.T) {
 			repo := filesystem.NewPostRepo(pathWithInvalidPost)
-			expectedPosts := []posts.Post{testPost1, testPost2}
+			expectedPosts := []blog.Post{testPost1, testPost2}
 
 			actualPosts, err := repo.GetAllPosts()
 
@@ -74,7 +74,7 @@ func TestPostRepo(t *testing.T) {
 
 		t.Run("Given a path other types of files, it ignores the other files", func(t *testing.T) {
 			repo := filesystem.NewPostRepo(pathWithDifferentFiles)
-			expectedPosts := []posts.Post{testPost1}
+			expectedPosts := []blog.Post{testPost1}
 
 			actualPosts, err := repo.GetAllPosts()
 
@@ -84,7 +84,7 @@ func TestPostRepo(t *testing.T) {
 	})
 }
 
-var testPost1 = posts.Post{
+var testPost1 = blog.Post{
 	Title:  "Test Post 1",
 	Author: "Geison Biazus",
 	Path:   "test-post-1",
@@ -95,7 +95,7 @@ var testPost1 = posts.Post{
 		"Content\n",
 }
 
-var testPost2 = posts.Post{
+var testPost2 = blog.Post{
 	Title:   "Test Post 2",
 	Author:  "Geison Biazus",
 	Path:    "test-post-2",
@@ -103,7 +103,7 @@ var testPost2 = posts.Post{
 	Content: "",
 }
 
-var testPost3 = posts.Post{
+var testPost3 = blog.Post{
 	Title:   "Test Post 3",
 	Author:  "Geison Biazus",
 	Path:    "test-post-3",

--- a/internal/app/context.go
+++ b/internal/app/context.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/geisonbiazus/blog/internal/adapters/postrepo/filesystem"
 	"github.com/geisonbiazus/blog/internal/adapters/renderer/goldmark"
-	"github.com/geisonbiazus/blog/internal/core/posts"
+	"github.com/geisonbiazus/blog/internal/core/blog"
 	"github.com/geisonbiazus/blog/internal/ui/web"
 	"github.com/geisonbiazus/blog/pkg/env"
 )
@@ -48,12 +48,12 @@ func (c *Context) UseCases() *web.UseCases {
 	}
 }
 
-func (c *Context) ViewPostUseCase() *posts.ViewPostUseCase {
-	return posts.NewVewPostUseCase(c.PostRepo(), c.Renderer())
+func (c *Context) ViewPostUseCase() *blog.ViewPostUseCase {
+	return blog.NewVewPostUseCase(c.PostRepo(), c.Renderer())
 }
 
-func (c *Context) ListPostsUseCase() *posts.ListPostsUseCase {
-	return posts.NewListPostsUseCase(c.PostRepo())
+func (c *Context) ListPostsUseCase() *blog.ListPostsUseCase {
+	return blog.NewListPostsUseCase(c.PostRepo())
 }
 
 func (c *Context) PostRepo() *filesystem.PostRepo {

--- a/internal/core/blog/doubles_test.go
+++ b/internal/core/blog/doubles_test.go
@@ -1,26 +1,24 @@
-package posts_test
+package blog_test
 
-import (
-	"github.com/geisonbiazus/blog/internal/core/posts"
-)
+import "github.com/geisonbiazus/blog/internal/core/blog"
 
 type PostRepoSpy struct {
 	ReceivedPath string
-	ReturnPost   posts.Post
-	ReturnPosts  []posts.Post
+	ReturnPost   blog.Post
+	ReturnPosts  []blog.Post
 	ReturnError  error
 }
 
 func NewPostRepoSpy() *PostRepoSpy {
-	return &PostRepoSpy{ReturnPosts: []posts.Post{}}
+	return &PostRepoSpy{ReturnPosts: []blog.Post{}}
 }
 
-func (r *PostRepoSpy) GetPostByPath(path string) (posts.Post, error) {
+func (r *PostRepoSpy) GetPostByPath(path string) (blog.Post, error) {
 	r.ReceivedPath = path
 	return r.ReturnPost, r.ReturnError
 }
 
-func (r *PostRepoSpy) GetAllPosts() ([]posts.Post, error) {
+func (r *PostRepoSpy) GetAllPosts() ([]blog.Post, error) {
 	return r.ReturnPosts, r.ReturnError
 }
 

--- a/internal/core/blog/entities.go
+++ b/internal/core/blog/entities.go
@@ -1,4 +1,4 @@
-package posts
+package blog
 
 import "time"
 

--- a/internal/core/blog/list_posts_use_case.go
+++ b/internal/core/blog/list_posts_use_case.go
@@ -1,4 +1,4 @@
-package posts
+package blog
 
 type ListPostsUseCase struct {
 	postRepo PostRepo

--- a/internal/core/blog/list_posts_use_case_test.go
+++ b/internal/core/blog/list_posts_use_case_test.go
@@ -1,22 +1,22 @@
-package posts_test
+package blog_test
 
 import (
 	"errors"
 	"testing"
 
-	"github.com/geisonbiazus/blog/internal/core/posts"
+	"github.com/geisonbiazus/blog/internal/core/blog"
 	"github.com/geisonbiazus/blog/pkg/assert"
 )
 
 type listPostsUseCaseFixture struct {
-	usecase *posts.ListPostsUseCase
+	usecase *blog.ListPostsUseCase
 	repo    *PostRepoSpy
 }
 
 func TestTestListPostsUseCase(t *testing.T) {
 	setup := func() *listPostsUseCaseFixture {
 		repo := NewPostRepoSpy()
-		usecase := posts.NewListPostsUseCase(repo)
+		usecase := blog.NewListPostsUseCase(repo)
 		return &listPostsUseCaseFixture{
 			usecase: usecase,
 			repo:    repo,
@@ -28,19 +28,19 @@ func TestTestListPostsUseCase(t *testing.T) {
 
 		result, err := f.usecase.Run()
 
-		assert.DeepEqual(t, []posts.Post{}, result)
+		assert.DeepEqual(t, []blog.Post{}, result)
 		assert.Nil(t, err)
 	})
 
 	t.Run("Given some posts, it returns them", func(t *testing.T) {
 		f := setup()
 
-		postList := []posts.Post{newPost()}
-		f.repo.ReturnPosts = postList
+		posts := []blog.Post{newPost()}
+		f.repo.ReturnPosts = posts
 
 		result, err := f.usecase.Run()
 
-		assert.DeepEqual(t, postList, result)
+		assert.DeepEqual(t, posts, result)
 		assert.Nil(t, err)
 	})
 
@@ -51,7 +51,7 @@ func TestTestListPostsUseCase(t *testing.T) {
 
 		result, err := f.usecase.Run()
 
-		assert.DeepEqual(t, []posts.Post{}, result)
+		assert.DeepEqual(t, []blog.Post{}, result)
 		assert.Equal(t, f.repo.ReturnError, err)
 	})
 }

--- a/internal/core/blog/ports.go
+++ b/internal/core/blog/ports.go
@@ -1,4 +1,4 @@
-package posts
+package blog
 
 import "errors"
 

--- a/internal/core/blog/view_post_use_case.go
+++ b/internal/core/blog/view_post_use_case.go
@@ -1,4 +1,4 @@
-package posts
+package blog
 
 type ViewPostUseCase struct {
 	postRepo PostRepo

--- a/internal/core/blog/view_post_use_case_test.go
+++ b/internal/core/blog/view_post_use_case_test.go
@@ -1,16 +1,16 @@
-package posts_test
+package blog_test
 
 import (
 	"errors"
 	"testing"
 	"time"
 
-	"github.com/geisonbiazus/blog/internal/core/posts"
+	"github.com/geisonbiazus/blog/internal/core/blog"
 	"github.com/geisonbiazus/blog/pkg/assert"
 )
 
 type viewPostUseCaseFixture struct {
-	usecase  *posts.ViewPostUseCase
+	usecase  *blog.ViewPostUseCase
 	repo     *PostRepoSpy
 	renderer *RendererSpy
 }
@@ -19,7 +19,7 @@ func TestViewPostUseCase(t *testing.T) {
 	setup := func() *viewPostUseCaseFixture {
 		repo := NewPostRepoSpy()
 		renderer := NewRendererSpy()
-		usecase := posts.NewVewPostUseCase(repo, renderer)
+		usecase := blog.NewVewPostUseCase(repo, renderer)
 
 		return &viewPostUseCaseFixture{
 			usecase:  usecase,
@@ -31,13 +31,13 @@ func TestViewPostUseCase(t *testing.T) {
 	t.Run("It returns error when post is not found", func(t *testing.T) {
 		f := setup()
 
-		f.repo.ReturnError = posts.ErrPostNotFound
+		f.repo.ReturnError = blog.ErrPostNotFound
 
 		body, err := f.usecase.Run("path")
 
 		assert.Equal(t, "path", f.repo.ReceivedPath)
-		assert.DeepEqual(t, posts.RenderedPost{}, body)
-		assert.Equal(t, posts.ErrPostNotFound, err)
+		assert.DeepEqual(t, blog.RenderedPost{}, body)
+		assert.Equal(t, blog.ErrPostNotFound, err)
 	})
 
 	t.Run("It returns the rendered post when post is found", func(t *testing.T) {
@@ -51,7 +51,7 @@ func TestViewPostUseCase(t *testing.T) {
 
 		assert.Equal(t, "path", f.repo.ReceivedPath)
 		assert.Equal(t, post.Content, f.renderer.ReceivedContent)
-		assert.DeepEqual(t, rennderedPost, posts.RenderedPost{
+		assert.DeepEqual(t, rennderedPost, blog.RenderedPost{
 			Title:   post.Title,
 			Author:  post.Author,
 			Time:    post.Time,
@@ -67,15 +67,15 @@ func TestViewPostUseCase(t *testing.T) {
 
 		rennderedPost, err := f.usecase.Run("path")
 		assert.Equal(t, "path", f.repo.ReceivedPath)
-		assert.DeepEqual(t, rennderedPost, posts.RenderedPost{})
+		assert.DeepEqual(t, rennderedPost, blog.RenderedPost{})
 		assert.Equal(t, f.renderer.ReturnError, err)
 	})
 }
 
-func newPost() posts.Post {
+func newPost() blog.Post {
 	postTime, _ := time.Parse(time.RFC3339, "2021-04-03T00:00:00+00:00")
 
-	return posts.Post{
+	return blog.Post{
 		Title:   "Title",
 		Author:  "Author",
 		Time:    postTime,

--- a/internal/ui/web/list_posts_handler.go
+++ b/internal/ui/web/list_posts_handler.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/geisonbiazus/blog/internal/core/posts"
+	"github.com/geisonbiazus/blog/internal/core/blog"
 )
 
 type ListPostsHandler struct {
@@ -20,10 +20,10 @@ func NewListPostsHandler(usecase ListPostUseCase, templateRenderer *TemplateRend
 }
 
 func (h *ListPostsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	postList, err := h.usecase.Run()
+	posts, err := h.usecase.Run()
 
 	if err == nil {
-		models := h.toViewModelList(postList)
+		models := h.toViewModelList(posts)
 		w.WriteHeader(http.StatusOK)
 		h.template.Render(w, "list_posts.html", models)
 	} else {
@@ -32,18 +32,18 @@ func (h *ListPostsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (h *ListPostsHandler) toViewModelList(postList []posts.Post) []postListViewModel {
-	models := []postListViewModel{}
+func (h *ListPostsHandler) toViewModelList(posts []blog.Post) []postsViewModel {
+	models := []postsViewModel{}
 
-	for _, post := range postList {
+	for _, post := range posts {
 		models = append(models, h.toViewModel(post))
 	}
 
 	return models
 }
 
-func (h *ListPostsHandler) toViewModel(post posts.Post) postListViewModel {
-	return postListViewModel{
+func (h *ListPostsHandler) toViewModel(post blog.Post) postsViewModel {
+	return postsViewModel{
 		Title:  post.Title,
 		Author: post.Author,
 		Date:   post.Time.Format(DateFormat),
@@ -51,7 +51,7 @@ func (h *ListPostsHandler) toViewModel(post posts.Post) postListViewModel {
 	}
 }
 
-type postListViewModel struct {
+type postsViewModel struct {
 	Title  string
 	Path   string
 	Author string

--- a/internal/ui/web/list_posts_handler_test.go
+++ b/internal/ui/web/list_posts_handler_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/geisonbiazus/blog/internal/core/posts"
+	"github.com/geisonbiazus/blog/internal/core/blog"
 	"github.com/geisonbiazus/blog/internal/ui/web"
 	"github.com/geisonbiazus/blog/pkg/assert"
 	"github.com/geisonbiazus/blog/pkg/testhelper"
@@ -32,7 +32,7 @@ func TestListPostsHandler(t *testing.T) {
 	t.Run("Given a list of posts exists it renders the posts", func(t *testing.T) {
 		f := setup()
 
-		f.usecase.ReturnPosts = []posts.Post{post2, post1}
+		f.usecase.ReturnPosts = []blog.Post{post2, post1}
 
 		res := doGetRequest(f.handler, "/index")
 		body := testhelper.ReadResponseBody(res)
@@ -55,7 +55,8 @@ func TestListPostsHandler(t *testing.T) {
 	})
 }
 
-func assertContainsListedPost(t *testing.T, body string, post posts.Post) {
+func assertContainsListedPost(t *testing.T, body string, post blog.Post) {
+	t.Helper()
 	assert.Contains(t, body, post.Title)
 	assert.Contains(t, body, post.Author)
 	assert.Contains(t, body, post.Time.Format(web.DateFormat))
@@ -63,22 +64,22 @@ func assertContainsListedPost(t *testing.T, body string, post posts.Post) {
 }
 
 type listPostUseCaseSpy struct {
-	ReturnPosts []posts.Post
+	ReturnPosts []blog.Post
 	ReturnError error
 }
 
-func (u *listPostUseCaseSpy) Run() ([]posts.Post, error) {
+func (u *listPostUseCaseSpy) Run() ([]blog.Post, error) {
 	return u.ReturnPosts, u.ReturnError
 }
 
-var post1 = posts.Post{
+var post1 = blog.Post{
 	Title:  "Test Post 1",
 	Author: "Geison Biazus",
 	Path:   "test-post-1",
 	Time:   testhelper.ParseTime("2021-04-05T18:47:00Z"),
 }
 
-var post2 = posts.Post{
+var post2 = blog.Post{
 	Title:  "Test Post 2",
 	Author: "Geison Biazus",
 	Path:   "test-post-2",

--- a/internal/ui/web/ports.go
+++ b/internal/ui/web/ports.go
@@ -1,6 +1,6 @@
 package web
 
-import "github.com/geisonbiazus/blog/internal/core/posts"
+import "github.com/geisonbiazus/blog/internal/core/blog"
 
 type UseCases struct {
 	ViewPost  ViewPostUseCase
@@ -8,9 +8,9 @@ type UseCases struct {
 }
 
 type ViewPostUseCase interface {
-	Run(path string) (posts.RenderedPost, error)
+	Run(path string) (blog.RenderedPost, error)
 }
 
 type ListPostUseCase interface {
-	Run() ([]posts.Post, error)
+	Run() ([]blog.Post, error)
 }

--- a/internal/ui/web/view_post_handler.go
+++ b/internal/ui/web/view_post_handler.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"path"
 
-	"github.com/geisonbiazus/blog/internal/core/posts"
+	"github.com/geisonbiazus/blog/internal/core/blog"
 )
 
 type ViewPostHandler struct {
@@ -28,7 +28,7 @@ func (h *ViewPostHandler) ServeHTTP(res http.ResponseWriter, req *http.Request) 
 	case nil:
 		res.WriteHeader(http.StatusOK)
 		h.template.Render(res, "view_post.html", h.toViewModel(renderedPost))
-	case posts.ErrPostNotFound:
+	case blog.ErrPostNotFound:
 		res.WriteHeader(http.StatusNotFound)
 		h.template.Render(res, "404.html", nil)
 	default:
@@ -37,7 +37,7 @@ func (h *ViewPostHandler) ServeHTTP(res http.ResponseWriter, req *http.Request) 
 	}
 }
 
-func (h *ViewPostHandler) toViewModel(p posts.RenderedPost) postViewModel {
+func (h *ViewPostHandler) toViewModel(p blog.RenderedPost) postViewModel {
 	return postViewModel{
 		Title:   p.Title,
 		Author:  p.Author,

--- a/internal/ui/web/view_post_handler_test.go
+++ b/internal/ui/web/view_post_handler_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/geisonbiazus/blog/internal/core/posts"
+	"github.com/geisonbiazus/blog/internal/core/blog"
 	"github.com/geisonbiazus/blog/internal/ui/web"
 	"github.com/geisonbiazus/blog/pkg/assert"
 	"github.com/geisonbiazus/blog/pkg/testhelper"
@@ -47,7 +47,7 @@ func TestViewPostHandler(t *testing.T) {
 	t.Run("Given a wrong post path it responds with not found", func(t *testing.T) {
 		f := setup()
 
-		f.usecase.ReturnError = posts.ErrPostNotFound
+		f.usecase.ReturnError = blog.ErrPostNotFound
 
 		res := doGetRequest(f.handler, "/posts/post-path")
 		body := testhelper.ReadResponseBody(res)
@@ -71,8 +71,8 @@ func TestViewPostHandler(t *testing.T) {
 	})
 }
 
-func buildRenderedPost() posts.RenderedPost {
-	return posts.RenderedPost{
+func buildRenderedPost() blog.RenderedPost {
+	return blog.RenderedPost{
 		Title:   "post title",
 		Author:  "post author",
 		Time:    testhelper.ParseTime("2021-04-03T00:00:00+00:00"),
@@ -89,7 +89,7 @@ func doGetRequest(handler http.Handler, path string) *http.Response {
 	return rw.Result()
 }
 
-func assertContainsRenderedPost(t *testing.T, body string, renderedPost posts.RenderedPost) {
+func assertContainsRenderedPost(t *testing.T, body string, renderedPost blog.RenderedPost) {
 	assert.Contains(t, body, renderedPost.Title)
 	assert.Contains(t, body, renderedPost.Author)
 	assert.Contains(t, body, renderedPost.Time.Format(web.DateFormat))
@@ -98,11 +98,11 @@ func assertContainsRenderedPost(t *testing.T, body string, renderedPost posts.Re
 
 type viewPostUseCaseSpy struct {
 	ReceivedPath string
-	ReturnPost   posts.RenderedPost
+	ReturnPost   blog.RenderedPost
 	ReturnError  error
 }
 
-func (u *viewPostUseCaseSpy) Run(path string) (posts.RenderedPost, error) {
+func (u *viewPostUseCaseSpy) Run(path string) (blog.RenderedPost, error) {
 	u.ReceivedPath = path
 	return u.ReturnPost, u.ReturnError
 }


### PR DESCRIPTION
Rename `core/posts` package to `core/blog` to not steal good variable names like `post` or `posts`