### PR TITLE
Save UserID on discussion.Author

### DIFF
--- a/db/migrations/20230425113352_add_auth_user_id_to_discussion_authors.down.sql
+++ b/db/migrations/20230425113352_add_auth_user_id_to_discussion_authors.down.sql
@@ -1,0 +1,3 @@
+BEGIN;
+ALTER TABLE discussion_authors DROP COLUMN IF EXISTS auth_user_id;
+COMMIT;

--- a/db/migrations/20230425113352_add_auth_user_id_to_discussion_authors.up.sql
+++ b/db/migrations/20230425113352_add_auth_user_id_to_discussion_authors.up.sql
@@ -1,0 +1,4 @@
+BEGIN;
+ALTER TABLE discussion_authors ADD COLUMN IF NOT EXISTS auth_user_id UUID;
+CREATE INDEX IF NOT EXISTS discussion_authors_auth_user_id_idx ON discussion_authors(auth_user_id);
+COMMIT;

--- a/internal/adapters/commentrepo/memory/comment_repo.go
+++ b/internal/adapters/commentrepo/memory/comment_repo.go
@@ -33,6 +33,16 @@ func (r *CommentRepo) GetAuthorByID(ctx context.Context, id string) (*discussion
 	return r.authors[id], nil
 }
 
+func (r *CommentRepo) GetAuthorByUserID(ctx context.Context, userID string) (*discussion.Author, error) {
+	for _, author := range r.authors {
+		if author.UserID == userID {
+			return author, nil
+		}
+	}
+
+	return nil, nil
+}
+
 func (r *CommentRepo) GetCommentsAndRepliesRecursively(ctx context.Context, subjectID string) ([]*discussion.Comment, error) {
 	result := []*discussion.Comment{}
 

--- a/internal/adapters/commentrepo/postgres/get_comments_and_replies_recursively.go
+++ b/internal/adapters/commentrepo/postgres/get_comments_and_replies_recursively.go
@@ -53,7 +53,7 @@ func (q *getCommentsAndRepliesRecursivelyQuery) executeQuery() error {
 		WITH RECURSIVE comments_and_replies as (
 			SELECT 
 				c.id, c.subject_id, c.author_id, c.markdown, c.html, c.created_at,
-				a.id AS author_id, a.name, a.avatar_url
+				a.id AS author_id, a.auth_user_id, a.name, a.avatar_url
 			FROM discussion_comments c
 			JOIN discussion_authors a ON c.author_id = a.id
 			WHERE c.subject_id = $1
@@ -62,7 +62,7 @@ func (q *getCommentsAndRepliesRecursivelyQuery) executeQuery() error {
 
 			SELECT 
 				c.id, c.subject_id, c.author_id, c.markdown, c.html, c.created_at,
-				a.id AS author_id, a.name, a.avatar_url
+				a.id AS author_id, a.auth_user_id, a.name, a.avatar_url
 			FROM discussion_comments c
 			JOIN discussion_authors a ON c.author_id = a.id
 			JOIN comments_and_replies cr ON c.subject_id = cr.id::TEXT
@@ -108,6 +108,7 @@ func (q *getCommentsAndRepliesRecursivelyQuery) scanRow(row *sql.Rows) (*discuss
 		&comment.HTML,
 		&comment.CreatedAt,
 		&comment.Author.ID,
+		&comment.Author.UserID,
 		&comment.Author.Name,
 		&comment.Author.AvatarURL,
 	)

--- a/internal/adapters/idgenerator/fake/id_generator.go
+++ b/internal/adapters/idgenerator/fake/id_generator.go
@@ -1,0 +1,13 @@
+package fake
+
+type IDGenerator struct {
+	ReturnID string
+}
+
+func NewIDGenerator() *IDGenerator {
+	return &IDGenerator{ReturnID: "FAKE_ID"}
+}
+
+func (g *IDGenerator) Generate() string {
+	return g.ReturnID
+}

--- a/internal/adapters/idgenerator/id_generator.go
+++ b/internal/adapters/idgenerator/id_generator.go
@@ -1,7 +1,14 @@
 package idgenerator
 
-import "github.com/geisonbiazus/blog/internal/adapters/idgenerator/uuid"
+import (
+	"github.com/geisonbiazus/blog/internal/adapters/idgenerator/fake"
+	"github.com/geisonbiazus/blog/internal/adapters/idgenerator/uuid"
+)
 
 func NewUUIDGenerator() *uuid.Generator {
 	return uuid.NewGenerator()
+}
+
+func NewFakeIDGenerator() *fake.IDGenerator {
+	return fake.NewIDGenerator()
 }

--- a/internal/app/context.go
+++ b/internal/app/context.go
@@ -132,7 +132,7 @@ func (c *Context) ListCommentsUseCase() *discussion.ListCommentsUseCase {
 }
 
 func (c *Context) SaveAuthorUseCase() *discussion.SaveAuthorUseCase {
-	return discussion.NewSaveAuthorUseCase(c.CommentRepo(), c.TransactionManager())
+	return discussion.NewSaveAuthorUseCase(c.CommentRepo(), c.TransactionManager(), c.IDGenerator())
 }
 
 // Adapters
@@ -218,7 +218,7 @@ func (c *Context) FakeOAuth2Provider() auth.OAuth2Provider {
 	return oauth2provider.NewFakeProvider(c.BaseURL)
 }
 
-func (c *Context) IDGenerator() auth.IDGenerator {
+func (c *Context) IDGenerator() shared.IDGenerator {
 	return idgenerator.NewUUIDGenerator()
 }
 

--- a/internal/core/auth/confirm_oauth_2_use_case.go
+++ b/internal/core/auth/confirm_oauth_2_use_case.go
@@ -13,7 +13,7 @@ type ConfirmOAuth2UseCase struct {
 	provider     OAuth2Provider
 	stateRepo    StateRepo
 	userRepo     UserRepo
-	idGen        IDGenerator
+	idGen        shared.IDGenerator
 	tokenEncoder TokenEncoder
 	txManager    shared.TransactionManager
 	publisher    shared.Publisher
@@ -23,7 +23,7 @@ func NewConfirmOAuth2UseCase(
 	provider OAuth2Provider,
 	stateRepo StateRepo,
 	userRepo UserRepo,
-	idGen IDGenerator,
+	idGen shared.IDGenerator,
 	tokenEncoder TokenEncoder,
 	txManager shared.TransactionManager,
 	publisher shared.Publisher,

--- a/internal/core/auth/confirm_oauth_2_use_case_test.go
+++ b/internal/core/auth/confirm_oauth_2_use_case_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	fakeidgenerator "github.com/geisonbiazus/blog/internal/adapters/idgenerator/fake"
 	fakepublisher "github.com/geisonbiazus/blog/internal/adapters/publisher/fake"
 	staterepo "github.com/geisonbiazus/blog/internal/adapters/staterepo/memory"
 	"github.com/geisonbiazus/blog/internal/adapters/transactionmanager/fake"
@@ -20,7 +21,7 @@ type confirmOAuth2UseCaseFixture struct {
 	provider     *OAuth2ProviderSpy
 	stateRepo    *staterepo.StateRepo
 	userRepo     *userrepo.UserRepo
-	idGen        *IDGeneratorStub
+	idGen        *fakeidgenerator.IDGenerator
 	tokenEncoder *TokenEncoderSpy
 	publisher    *fakepublisher.Publisher
 	ctx          context.Context
@@ -41,7 +42,7 @@ func TestConfirmOAuth2UseCase(t *testing.T) {
 		provider := NewOAuth2ProviderSpy()
 		stateRepo := staterepo.NewStateRepo()
 		userRepo := userrepo.NewUserRepo()
-		idGen := NewIDGeneratorStub()
+		idGen := fakeidgenerator.NewIDGenerator()
 		tokenEncoder := NewTokenEncoderSpy()
 		txManager := fake.NewTransactionManager()
 		publisher := fakepublisher.NewPublisher()

--- a/internal/core/auth/ports.go
+++ b/internal/core/auth/ports.go
@@ -10,10 +10,6 @@ type OAuth2Provider interface {
 	AuthenticatedUser(ctx context.Context, code string) (ProviderUser, error)
 }
 
-type IDGenerator interface {
-	Generate() string
-}
-
 type StateRepo interface {
 	AddState(state string) error
 	Exists(state string) (bool, error)

--- a/internal/core/auth/request_oauth_2_use_case.go
+++ b/internal/core/auth/request_oauth_2_use_case.go
@@ -1,16 +1,20 @@
 package auth
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/geisonbiazus/blog/internal/core/shared"
+)
 
 type RequestOAuth2UseCase struct {
 	provider  OAuth2Provider
-	idGen     IDGenerator
+	idGen     shared.IDGenerator
 	stateRepo StateRepo
 }
 
 func NewRequestOAuth2UseCase(
 	provider OAuth2Provider,
-	idGen IDGenerator,
+	idGen shared.IDGenerator,
 	stateRepo StateRepo,
 ) *RequestOAuth2UseCase {
 	return &RequestOAuth2UseCase{

--- a/internal/core/discussion/entities.go
+++ b/internal/core/discussion/entities.go
@@ -24,6 +24,7 @@ type Author struct {
 	Persisted bool
 
 	ID        string
+	UserID    string
 	Name      string
 	AvatarURL string
 }

--- a/internal/core/discussion/ports.go
+++ b/internal/core/discussion/ports.go
@@ -5,5 +5,6 @@ import "context"
 type CommentRepo interface {
 	SaveAuthor(ctx context.Context, author *Author) error
 	GetAuthorByID(ctx context.Context, id string) (*Author, error)
+	GetAuthorByUserID(ctx context.Context, userID string) (*Author, error)
 	GetCommentsAndRepliesRecursively(ctx context.Context, subjectID string) ([]*Comment, error)
 }

--- a/internal/core/discussion/test/helpers.go
+++ b/internal/core/discussion/test/helpers.go
@@ -22,6 +22,7 @@ func NewComment(params discussion.Comment) *discussion.Comment {
 func NewAuthor(params discussion.Author) *discussion.Author {
 	return &discussion.Author{
 		ID:        valueOrDefault(params.ID, "AUTHOR_ID"),
+		UserID:    valueOrDefault(params.UserID, "USER_ID"),
 		Name:      valueOrDefault(params.Name, "Author"),
 		AvatarURL: valueOrDefault(params.AvatarURL, "http://example.com/avatar"),
 	}

--- a/internal/core/shared/ports.go
+++ b/internal/core/shared/ports.go
@@ -20,3 +20,7 @@ var NeverExpire time.Duration = 0
 type Publisher interface {
 	Publish(event Event) error
 }
+
+type IDGenerator interface {
+	Generate() string
+}

--- a/internal/ui/subscriptions/save_author_subscriber.go
+++ b/internal/ui/subscriptions/save_author_subscriber.go
@@ -29,7 +29,7 @@ func (s *SaveAuthorSubscriber) Start() {
 
 func (s *SaveAuthorSubscriber) inputFrom(event shared.Event) discussion.SaveAuthorInput {
 	return discussion.SaveAuthorInput{
-		ID:        event.Payload["ID"].(string),
+		UserID:    event.Payload["ID"].(string),
 		Name:      event.Payload["Name"].(string),
 		AvatarURL: event.Payload["AvatarURL"].(string),
 	}

--- a/internal/ui/subscriptions/save_author_subscriber_test.go
+++ b/internal/ui/subscriptions/save_author_subscriber_test.go
@@ -43,7 +43,7 @@ func (s *SaveAuthorSubscriberSuite) TestStart() {
 
 		s.True(<-s.usecase.Ran)
 		s.Equal(discussion.SaveAuthorInput{
-			ID:        "ID",
+			UserID:    "ID",
 			Name:      "Name",
 			AvatarURL: "http://example.com/avatar.png",
 		}, s.usecase.ReceivedInput)

--- a/internal/ui/subscriptions/update_author_subscriber.go
+++ b/internal/ui/subscriptions/update_author_subscriber.go
@@ -29,7 +29,7 @@ func (s *UpdateAuthorSubscriber) Start() {
 
 func (s *UpdateAuthorSubscriber) inputFrom(event shared.Event) discussion.SaveAuthorInput {
 	return discussion.SaveAuthorInput{
-		ID:        event.Payload["ID"].(string),
+		UserID:    event.Payload["ID"].(string),
 		Name:      event.Payload["Name"].(string),
 		AvatarURL: event.Payload["AvatarURL"].(string),
 	}

--- a/internal/ui/subscriptions/update_author_subscriber_test.go
+++ b/internal/ui/subscriptions/update_author_subscriber_test.go
@@ -43,7 +43,7 @@ func (s *UpdateAuthorSubscriberSuite) TestStart() {
 
 		s.True(<-s.usecase.Ran)
 		s.Equal(discussion.SaveAuthorInput{
-			ID:        "ID",
+			UserID:    "ID",
 			Name:      "Name",
 			AvatarURL: "http://example.com/avatar.png",
 		}, s.usecase.ReceivedInput)


### PR DESCRIPTION
Instead of `auth.User` and `dicussion.Author` sharing the same ID, a new field is added to the `discussion.Author` to make the relationship clearer and allowing authors to have unique IDs

Closes #74 